### PR TITLE
Fix command name of crowddetector

### DIFF
--- a/services
+++ b/services
@@ -48,7 +48,7 @@ case "${command}" in
 		stoppingContainers;
 		startingContainers;
 		;;
-	"crowd-detector")
+	"crowddetector")
 		stoppingContainers;
 		startingContainers;
 		;;


### PR DESCRIPTION
The "crowd-detector" command in services script should be "crowddetector".
A hyphen is not necessary. Container startup fails because the command is incorrect.